### PR TITLE
Fixed a typo preventing the api working with v13

### DIFF
--- a/pyfacebook/api/graph.py
+++ b/pyfacebook/api/graph.py
@@ -28,7 +28,7 @@ class GraphAPI:
         "v10.0",
         "v11.0",
         "v12.0",
-        "V13.0",
+        "v13.0",
     ]
     GRAPH_URL = "https://graph.facebook.com/"
     AUTHORIZATION_URL = "https://www.facebook.com/dialog/oauth"


### PR DESCRIPTION
Typo in graph.py prevented API from working with v13.0 FB Api.